### PR TITLE
Buffered parsing

### DIFF
--- a/mcJSON.h
+++ b/mcJSON.h
@@ -61,6 +61,11 @@ typedef enum mcJSON_Type {
 	mcJSON_Object = 6
 } mcJSON_Type;
 
+/* alias buffer_t to mempool_t, the mempool_t type defines a contiguous
+ * chunk of memory that is used for parsing a json into it. */
+typedef buffer_t mempool_t;
+
+
 #define mcJSON_IsReference 256
 #define mcJSON_StringIsConst 512
 
@@ -106,19 +111,19 @@ extern mcJSON *mcJSON_GetArrayItem(mcJSON *array, size_t item);
 extern mcJSON *mcJSON_GetObjectItem(mcJSON *object,const char *string);
 
 /* These calls create a mcJSON item of the appropriate type. */
-extern mcJSON *mcJSON_CreateNull(void);
-extern mcJSON *mcJSON_CreateTrue(void);
-extern mcJSON *mcJSON_CreateFalse(void);
-extern mcJSON *mcJSON_CreateBool(int b);
-extern mcJSON *mcJSON_CreateNumber(double num);
-extern mcJSON *mcJSON_CreateString(const char *string);
-extern mcJSON *mcJSON_CreateArray(void);
-extern mcJSON *mcJSON_CreateObject(void);
+extern mcJSON *mcJSON_CreateNull(mempool_t *pool);
+extern mcJSON *mcJSON_CreateTrue(mempool_t *pool);
+extern mcJSON *mcJSON_CreateFalse(mempool_t *pool);
+extern mcJSON *mcJSON_CreateBool(bool b, mempool_t *pool);
+extern mcJSON *mcJSON_CreateNumber(double num, mempool_t *pool);
+extern mcJSON *mcJSON_CreateString(const char *string, mempool_t *pool);
+extern mcJSON *mcJSON_CreateArray(mempool_t *pool);
+extern mcJSON *mcJSON_CreateObject(mempool_t *pool);
 
 /* These utilities create an Array of count items. */
-extern mcJSON *mcJSON_CreateIntArray(const int *numbers, size_t count);
-extern mcJSON *mcJSON_CreateDoubleArray(const double *numbers, size_t count);
-extern mcJSON *mcJSON_CreateStringArray(const char **strings, size_t count);
+extern mcJSON *mcJSON_CreateIntArray(const int *numbers, size_t count, mempool_t *pool);
+extern mcJSON *mcJSON_CreateDoubleArray(const double *numbers, size_t count, mempool_t *pool);
+extern mcJSON *mcJSON_CreateStringArray(const char **strings, size_t count, mempool_t *pool);
 
 /* Append item to the specified array/object. */
 extern void mcJSON_AddItemToArray(mcJSON *array, mcJSON *item);
@@ -140,7 +145,7 @@ extern void mcJSON_ReplaceItemInArray(mcJSON *array, size_t index, mcJSON *newit
 extern void mcJSON_ReplaceItemInObject(mcJSON *object, const char *string, mcJSON *newitem);
 
 /* Duplicate a mcJSON item */
-extern mcJSON *mcJSON_Duplicate(mcJSON *item,int recurse);
+extern mcJSON *mcJSON_Duplicate(mcJSON *item, int recurse, mempool_t *pool);
 /* Duplicate will create a new, identical mcJSON item to the one you pass, in new memory that will
 need to be released. With recurse!=0, it will duplicate any children connected to the item.
 The item->next and ->prev pointers are always zero on return from Duplicate. */
@@ -148,12 +153,12 @@ The item->next and ->prev pointers are always zero on return from Duplicate. */
 extern void mcJSON_Minify(buffer_t *json);
 
 /* Macros for creating things quickly. */
-#define mcJSON_AddNullToObject(object,name)		mcJSON_AddItemToObject(object, name, mcJSON_CreateNull())
-#define mcJSON_AddTrueToObject(object,name)		mcJSON_AddItemToObject(object, name, mcJSON_CreateTrue())
-#define mcJSON_AddFalseToObject(object,name)		mcJSON_AddItemToObject(object, name, mcJSON_CreateFalse())
-#define mcJSON_AddBoolToObject(object,name,b)	mcJSON_AddItemToObject(object, name, mcJSON_CreateBool(b))
-#define mcJSON_AddNumberToObject(object,name,n)	mcJSON_AddItemToObject(object, name, mcJSON_CreateNumber(n))
-#define mcJSON_AddStringToObject(object,name,s)	mcJSON_AddItemToObject(object, name, mcJSON_CreateString(s))
+#define mcJSON_AddNullToObject(object, name, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateNull(pool))
+#define mcJSON_AddTrueToObject(object,name, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateTrue(pool))
+#define mcJSON_AddFalseToObject(object, name, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateFalse(pool))
+#define mcJSON_AddBoolToObject(object, name, b, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateBool(b, pool))
+#define mcJSON_AddNumberToObject(object, name, n, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateNumber(n, pool))
+#define mcJSON_AddStringToObject(object, name, s, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateString(s, pool))
 
 /* When assigning an integer value, it needs to be propagated to valuedouble too. */
 #define mcJSON_SetIntValue(object,val)			((object)?(object)->valueint=(object)->valuedouble=(val):(val))

--- a/mcJSON.h
+++ b/mcJSON.h
@@ -94,6 +94,13 @@ extern void mcJSON_InitHooks(mcJSON_Hooks* hooks);
 
 /* Supply a block of JSON, and this returns a mcJSON object you can interrogate. Call mcJSON_Delete when finished. */
 extern mcJSON *mcJSON_Parse(buffer_t *json);
+/* Parse an object - create a new root, and populate.
+ * This supports buffered parsing, a big chunk of memory
+ * is allocated once and the json tree is parsed into it.
+ * The size needs to be large enough otherwise allocation
+ * will fail at some point. */
+extern mcJSON *mcJSON_ParseWithBuffer(buffer_t *json, mempool_t *pool);
+extern mcJSON *mcJSON_ParseBuffered(buffer_t *json, size_t bufer_length);
 /* Render a mcJSON entity to text for transfer/storage. Free the char* when finished. */
 extern buffer_t *mcJSON_Print(mcJSON *item);
 /* Render a mcJSON entity to text for transfer/storage without any formatting. Free the char* when finished. */

--- a/mcJSON.h
+++ b/mcJSON.h
@@ -126,12 +126,12 @@ extern mcJSON *mcJSON_CreateDoubleArray(const double *numbers, size_t count, mem
 extern mcJSON *mcJSON_CreateStringArray(const char **strings, size_t count, mempool_t *pool);
 
 /* Append item to the specified array/object. */
-extern void mcJSON_AddItemToArray(mcJSON *array, mcJSON *item);
-extern void mcJSON_AddItemToObject(mcJSON *object,const char *string,mcJSON *item);
-extern void mcJSON_AddItemToObjectCS(mcJSON *object,const char *string,mcJSON *item);	/* Use this when string is definitely const (i.e. a literal, or as good as), and will definitely survive the mcJSON object */
+extern void mcJSON_AddItemToArray(mcJSON *array, mcJSON *item, mempool_t *pool);
+extern void mcJSON_AddItemToObject(mcJSON *object,const char *string,mcJSON *item, mempool_t *pool);
+extern void mcJSON_AddItemToObjectCS(mcJSON *object,const char *string,mcJSON *item, mempool_t *pool);	/* Use this when string is definitely const (i.e. a literal, or as good as), and will definitely survive the mcJSON object */
 /* Append reference to item to the specified array/object. Use this when you want to add an existing mcJSON to a new mcJSON, but don't want to corrupt your existing mcJSON. */
-extern void mcJSON_AddItemReferenceToArray(mcJSON *array, mcJSON *item);
-extern void mcJSON_AddItemReferenceToObject(mcJSON *object, const char *string, mcJSON *item);
+extern void mcJSON_AddItemReferenceToArray(mcJSON *array, mcJSON *item, mempool_t *pool);
+extern void mcJSON_AddItemReferenceToObject(mcJSON *object, const char *string, mcJSON *item, mempool_t *pool);
 
 /* Remove/Detatch items from Arrays/Objects. */
 extern mcJSON *mcJSON_DetachItemFromArray(mcJSON *array, size_t index);
@@ -140,9 +140,9 @@ extern mcJSON *mcJSON_DetachItemFromObject(mcJSON *object,const char *string);
 extern void mcJSON_DeleteItemFromObject(mcJSON *object,const char *string);
 
 /* Update array items. */
-extern void mcJSON_InsertItemInArray(mcJSON *array, size_t index, mcJSON *newitem);	/* Shifts pre-existing items to the right. */
-extern void mcJSON_ReplaceItemInArray(mcJSON *array, size_t index, mcJSON *newitem);
-extern void mcJSON_ReplaceItemInObject(mcJSON *object, const char *string, mcJSON *newitem);
+extern void mcJSON_InsertItemInArray(mcJSON *array, size_t index, mcJSON *newitem, mempool_t *pool);	/* Shifts pre-existing items to the right. */
+extern void mcJSON_ReplaceItemInArray(mcJSON *array, size_t index, mcJSON *newitem, mempool_t *pool);
+extern void mcJSON_ReplaceItemInObject(mcJSON *object, const char *string, mcJSON *newitem, mempool_t *pool);
 
 /* Duplicate a mcJSON item */
 extern mcJSON *mcJSON_Duplicate(mcJSON *item, int recurse, mempool_t *pool);
@@ -153,12 +153,12 @@ The item->next and ->prev pointers are always zero on return from Duplicate. */
 extern void mcJSON_Minify(buffer_t *json);
 
 /* Macros for creating things quickly. */
-#define mcJSON_AddNullToObject(object, name, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateNull(pool))
-#define mcJSON_AddTrueToObject(object,name, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateTrue(pool))
-#define mcJSON_AddFalseToObject(object, name, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateFalse(pool))
-#define mcJSON_AddBoolToObject(object, name, b, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateBool(b, pool))
-#define mcJSON_AddNumberToObject(object, name, n, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateNumber(n, pool))
-#define mcJSON_AddStringToObject(object, name, s, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateString(s, pool))
+#define mcJSON_AddNullToObject(object, name, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateNull(pool), pool)
+#define mcJSON_AddTrueToObject(object,name, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateTrue(pool), pool)
+#define mcJSON_AddFalseToObject(object, name, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateFalse(pool), pool)
+#define mcJSON_AddBoolToObject(object, name, b, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateBool(b, pool), pool)
+#define mcJSON_AddNumberToObject(object, name, n, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateNumber(n, pool), pool)
+#define mcJSON_AddStringToObject(object, name, s, pool) mcJSON_AddItemToObject(object, name, mcJSON_CreateString(s, pool), pool)
 
 /* When assigning an integer value, it needs to be propagated to valuedouble too. */
 #define mcJSON_SetIntValue(object,val)			((object)?(object)->valueint=(object)->valuedouble=(val):(val))

--- a/mcJSON_Utils.c
+++ b/mcJSON_Utils.c
@@ -312,7 +312,7 @@ static int mcJSONUtils_ApplyPatch(mcJSON *object, mcJSON *patch) {
 			return 5;
 		}
 		if (opcode == 4) {
-			value = mcJSON_Duplicate(value, 1);
+			value = mcJSON_Duplicate(value, 1, NULL);
 		}
 		if (value == NULL) { /* out of memory for copy/move. */
 			return 6;
@@ -322,7 +322,7 @@ static int mcJSONUtils_ApplyPatch(mcJSON *object, mcJSON *patch) {
 		if (value == NULL) { /* missing "value" for add/replace. */
 			return 7;
 		}
-		value = mcJSON_Duplicate(value, 1);
+		value = mcJSON_Duplicate(value, 1, NULL);
 		if (value == NULL) { /* out of memory for add/replace. */
 			return 8;
 		}
@@ -383,19 +383,19 @@ int mcJSONUtils_ApplyPatches(mcJSON *object, mcJSON *patches) {
 }
 
 static void mcJSONUtils_GeneratePatch(mcJSON *patches, const char *op, const char *path, const char *suffix, mcJSON *val) {
-	mcJSON *patch = mcJSON_CreateObject();
-	mcJSON_AddItemToObject(patch, "op", mcJSON_CreateString(op));
+	mcJSON *patch = mcJSON_CreateObject(NULL);
+	mcJSON_AddItemToObject(patch, "op", mcJSON_CreateString(op, NULL));
 	if (suffix) {
 		size_t length = strlen(path) + mcJSONUtils_PointerEncodedstrlen(suffix) + 2;
 		char *newpath = (char*)malloc(length);
 		mcJSONUtils_PointerEncodedstrcpy(newpath + snprintf(newpath, length, "%s/", path), suffix);
-		mcJSON_AddItemToObject(patch, "path", mcJSON_CreateString(newpath));
+		mcJSON_AddItemToObject(patch, "path", mcJSON_CreateString(newpath, NULL));
 		free(newpath);
 	} else {
-		mcJSON_AddItemToObject(patch, "path", mcJSON_CreateString(path));
+		mcJSON_AddItemToObject(patch, "path", mcJSON_CreateString(path, NULL));
 	}
 	if (val) {
-		mcJSON_AddItemToObject(patch, "value", mcJSON_Duplicate(val, 1));
+		mcJSON_AddItemToObject(patch, "value", mcJSON_Duplicate(val, 1, NULL));
 	}
 	mcJSON_AddItemToArray(patches, patch);
 }
@@ -484,7 +484,7 @@ static void mcJSONUtils_CompareToPatch(mcJSON *patches, const char *path, mcJSON
 
 
 mcJSON* mcJSONUtils_GeneratePatches(mcJSON *from, mcJSON *to) {
-	mcJSON *patches = mcJSON_CreateArray();
+	mcJSON *patches = mcJSON_CreateArray(NULL);
 	mcJSONUtils_CompareToPatch(patches, "", from, to);
 	return patches;
 }

--- a/mcJSON_Utils.c
+++ b/mcJSON_Utils.c
@@ -350,13 +350,13 @@ static int mcJSONUtils_ApplyPatch(mcJSON *object, mcJSON *patch) {
 		return 9;
 	} else if (parent->type == mcJSON_Array) {
 		if (!strcmp(childptr, "-")) {
-			mcJSON_AddItemToArray(parent,value);
+			mcJSON_AddItemToArray(parent,value, NULL);
 		} else {
-			mcJSON_InsertItemInArray(parent, atoi(childptr), value);
+			mcJSON_InsertItemInArray(parent, atoi(childptr), value, NULL);
 		}
 	} else if (parent->type == mcJSON_Object) {
 		mcJSON_DeleteItemFromObject(parent, childptr);
-		mcJSON_AddItemToObject(parent, childptr, value);
+		mcJSON_AddItemToObject(parent, childptr, value, NULL);
 	} else {
 		mcJSON_Delete(value);
 	}
@@ -384,20 +384,20 @@ int mcJSONUtils_ApplyPatches(mcJSON *object, mcJSON *patches) {
 
 static void mcJSONUtils_GeneratePatch(mcJSON *patches, const char *op, const char *path, const char *suffix, mcJSON *val) {
 	mcJSON *patch = mcJSON_CreateObject(NULL);
-	mcJSON_AddItemToObject(patch, "op", mcJSON_CreateString(op, NULL));
+	mcJSON_AddItemToObject(patch, "op", mcJSON_CreateString(op, NULL), NULL);
 	if (suffix) {
 		size_t length = strlen(path) + mcJSONUtils_PointerEncodedstrlen(suffix) + 2;
 		char *newpath = (char*)malloc(length);
 		mcJSONUtils_PointerEncodedstrcpy(newpath + snprintf(newpath, length, "%s/", path), suffix);
-		mcJSON_AddItemToObject(patch, "path", mcJSON_CreateString(newpath, NULL));
+		mcJSON_AddItemToObject(patch, "path", mcJSON_CreateString(newpath, NULL), NULL);
 		free(newpath);
 	} else {
-		mcJSON_AddItemToObject(patch, "path", mcJSON_CreateString(path, NULL));
+		mcJSON_AddItemToObject(patch, "path", mcJSON_CreateString(path, NULL), NULL);
 	}
 	if (val) {
-		mcJSON_AddItemToObject(patch, "value", mcJSON_Duplicate(val, 1, NULL));
+		mcJSON_AddItemToObject(patch, "value", mcJSON_Duplicate(val, 1, NULL), NULL);
 	}
-	mcJSON_AddItemToArray(patches, patch);
+	mcJSON_AddItemToArray(patches, patch, NULL);
 }
 
 void mcJSONUtils_AddPatchToArray(mcJSON *array, const char *op, const char *path, mcJSON *val) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,3 +44,16 @@ foreach(json-file ${json-files})
     add_test(NAME "test-file-${json-file}-comparison"
         COMMAND cmake -E compare_files "${CMAKE_CURRENT_BINARY_DIR}/test-data/${json-file}.out" "${CMAKE_CURRENT_BINARY_DIR}/test-data/${json-file}.ref")
 endforeach(json-file ${json-files})
+
+#test buffered parsing
+add_executable(test-buffered-parse test-buffered-parse)
+target_link_libraries(test-buffered-parse mcjson)
+add_test(NAME test-buffered-parse
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/test-buffered-parse" "test-buffered-parse.out")
+if(NOT ("${MEMORYCHECK_COMMAND}" MATCHES "MEMORYCHECK_COMMAND-NOTFOUND"))
+    add_test(NAME "test-buffered-parse-valgrind"
+        COMMAND "${MEMORYCHECK_COMMAND}" ${MEMORYCHECK_COMMAND_OPTIONS} "${CMAKE_CURRENT_BINARY_DIR}/test-buffered-parse" "test-buffered-parse.out")
+endif(NOT ("${MEMORYCHECK_COMMAND}" MATCHES "MEMORYCHECK_COMMAND-NOTFOUND"))
+execute_process(COMMAND cmake -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/test-buffered-parse.ref" "${CMAKE_CURRENT_BINARY_DIR}/test-buffered-parse.ref")
+add_test(NAME test-buffered-parse-comparison
+    COMMAND cmake -E compare_files "${CMAKE_CURRENT_BINARY_DIR}/test-buffered-parse.out" "${CMAKE_CURRENT_BINARY_DIR}/test-buffered-parse.ref")

--- a/test/test-buffered-parse.c
+++ b/test/test-buffered-parse.c
@@ -1,0 +1,115 @@
+/*
+ * mcJSON, a modified version of cJSON, a simple JSON parser and generator.
+ *  Copyright (C) 2009 Dave Gamble
+ *  Copyright (C) 2015  Max Bruckner (FSMaxB)
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *  This file incorporates work covered by the following license notice:
+ *
+ * |  Copyright (c) 2009 Dave Gamble
+ * |
+ * |  Permission is hereby granted, free of charge, to any person obtaining a copy
+ * |  of this software and associated documentation files (the "Software"), to deal
+ * |  in the Software without restriction, including without limitation the rights
+ * |  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * |  copies of the Software, and to permit persons to whom the Software is
+ * |  furnished to do so, subject to the following conditions:
+ * |
+ * |  The above copyright notice and this permission notice shall be included in
+ * |  all copies or substantial portions of the Software.
+ * |
+ * |  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * |  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * |  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * |  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * |  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * |  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * |  THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../mcJSON.h"
+
+int main (int argc, char **argv) {
+	if ((argc != 1) && (argc != 2)) {
+		fprintf(stderr, "ERROR: Invalid arguments!\n");
+		fprintf(stderr, "Usage: %s [output_file]\n", argv[0]);
+		return EXIT_FAILURE;
+	}
+
+	FILE *output_file = NULL;
+	if ((argc == 2) && (argv[1] != NULL)) {
+		output_file = fopen(argv[1], "w");
+		if (output_file == NULL) {
+			fprintf(stderr, "ERROR: Failed to open file '%s'\n", argv[1]);;
+			return EXIT_FAILURE;
+		}
+	}
+
+	struct entry {
+		char *string;
+		size_t length;
+	};
+
+	/* a bunch of json: */
+	struct entry json[5];
+
+	json[0].string = "{\n\"name\": \"Jack (\\\"Bee\\\") Nimble\", \n\"format\": {\"type\":       \"rect\", \n\"width\":      1920, \n\"height\":     1080, \n\"interlace\":  false,\"frame rate\": 24\n}\n}";
+	json[0].length = 4000;
+
+	json[1].string = "[\"Sunday\", \"Monday\", \"Tuesday\", \"Wednesday\", \"Thursday\", \"Friday\", \"Saturday\"]";
+	json[1].length = 4000;
+
+	json[2].string = "[\n    [0, -1, 0],\n    [1, 0, 0],\n    [0, 0, 1]\n	]\n";
+	json[2].length = 4000;
+
+	json[3].string = "{\n		\"Image\": {\n			\"Width\":  800,\n			\"Height\": 600,\n			\"Title\":  \"View from 15th Floor\",\n			\"Thumbnail\": {\n				\"Url\":    \"http:/*www.example.com/image/481989943\",\n				\"Height\": 125,\n				\"Width\":  \"100\"\n			},\n			\"IDs\": [116, 943, 234, 38793]\n		}\n	}";
+	json[3].length = 4000;
+
+	json[4].string = "[\n	 {\n	 \"precision\": \"zip\",\n	 \"Latitude\":  37.7668,\n	 \"Longitude\": -122.3959,\n	 \"Address\":   \"\",\n	 \"City\":      \"SAN FRANCISCO\",\n	 \"State\":     \"CA\",\n	 \"Zip\":       \"94107\",\n	 \"Country\":   \"US\"\n	 },\n	 {\n	 \"precision\": \"zip\",\n	 \"Latitude\":  37.371991,\n	 \"Longitude\": -122.026020,\n	 \"Address\":   \"\",\n	 \"City\":      \"SUNNYVALE\",\n	 \"State\":     \"CA\",\n	 \"Zip\":       \"94085\",\n	 \"Country\":   \"US\"\n	 }\n	 ]";
+	json[4].length = 4000;
+
+	/* Process each json textblock by parsing, then rebuilding: */
+	for (size_t i = 0; i < (sizeof(json) / sizeof(struct entry)); i++) {
+		buffer_t *json_buffer = buffer_create_with_existing_array((unsigned char*)json[i].string, strlen(json[i].string) + 1);
+		mcJSON *json_tree = mcJSON_ParseBuffered(json_buffer, json[i].length);
+		if (json == NULL) {
+			fprintf(stderr, "ERROR: Failed on text %zi!\n", i);
+			if (output_file != NULL) {
+				fclose(output_file);
+			}
+			return EXIT_FAILURE;
+		}
+		buffer_t *print_buffer = mcJSON_Print(json_tree);
+		printf("%.*s\n", (int)print_buffer->content_length, (char*)print_buffer->content);
+		if (output_file != NULL) {
+			fprintf(output_file, "%.*s\n", (int)print_buffer->content_length, (char*)print_buffer->content);
+		}
+
+		// cleanup
+		buffer_destroy_from_heap(print_buffer);
+		buffer_destroy_from_heap((buffer_t*)json_tree);
+	}
+
+	if (output_file != NULL) {
+		fclose(output_file);
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/test/test-buffered-parse.ref
+++ b/test/test-buffered-parse.ref
@@ -1,0 +1,44 @@
+{
+	"name":	"Jack (\"Bee\") Nimble",
+	"format":	{
+		"type":	"rect",
+		"width":	1920,
+		"height":	1080,
+		"interlace":	false,
+		"frame rate":	24
+	}
+}
+["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+[[0, -1, 0], [1, 0, 0], [0, 0, 1]]
+{
+	"Image":	{
+		"Width":	800,
+		"Height":	600,
+		"Title":	"View from 15th Floor",
+		"Thumbnail":	{
+			"Url":	"http:/*www.example.com/image/481989943",
+			"Height":	125,
+			"Width":	"100"
+		},
+		"IDs":	[116, 943, 234, 38793]
+	}
+}
+[{
+		"precision":	"zip",
+		"Latitude":	37.766800,
+		"Longitude":	-122.395900,
+		"Address":	"",
+		"City":	"SAN FRANCISCO",
+		"State":	"CA",
+		"Zip":	"94107",
+		"Country":	"US"
+	}, {
+		"precision":	"zip",
+		"Latitude":	37.371991,
+		"Longitude":	-122.026020,
+		"Address":	"",
+		"City":	"SUNNYVALE",
+		"State":	"CA",
+		"Zip":	"94085",
+		"Country":	"US"
+	}]

--- a/test/test-objects.c
+++ b/test/test-objects.c
@@ -83,14 +83,14 @@ int create_objects(FILE *output_file) {
 	/* Here we construct some JSON standards, from the JSON site. */
 
 	/* Our "Video" datatype: */
-	root = mcJSON_CreateObject();
-	mcJSON_AddItemToObject(root, "name", mcJSON_CreateString("Jack (\"Bee\") Nimble"));
-	mcJSON_AddItemToObject(root, "format", fmt=mcJSON_CreateObject());
-	mcJSON_AddStringToObject(fmt, "type", "rect");
-	mcJSON_AddNumberToObject(fmt, "width", 1920);
-	mcJSON_AddNumberToObject(fmt, "height", 1080);
-	mcJSON_AddFalseToObject (fmt, "interlace");
-	mcJSON_AddNumberToObject(fmt, "frame rate", 24);
+	root = mcJSON_CreateObject(NULL);
+	mcJSON_AddItemToObject(root, "name", mcJSON_CreateString("Jack (\"Bee\") Nimble", NULL));
+	mcJSON_AddItemToObject(root, "format", fmt=mcJSON_CreateObject(NULL));
+	mcJSON_AddStringToObject(fmt, "type", "rect", NULL);
+	mcJSON_AddNumberToObject(fmt, "width", 1920, NULL);
+	mcJSON_AddNumberToObject(fmt, "height", 1080, NULL);
+	mcJSON_AddFalseToObject (fmt, "interlace", NULL);
+	mcJSON_AddNumberToObject(fmt, "frame rate", 24, NULL);
 
 	buffer_t *output = NULL;
 	/* Print to text, Delete the mcJSON, print it, release the string. */
@@ -106,7 +106,7 @@ int create_objects(FILE *output_file) {
 	buffer_destroy_from_heap(output);
 
 	/* Our "days of the week" array: */
-	root = mcJSON_CreateStringArray(strings, 7);
+	root = mcJSON_CreateStringArray(strings, 7, NULL);
 
 	output = mcJSON_Print(root);
 	mcJSON_Delete(root);
@@ -120,9 +120,9 @@ int create_objects(FILE *output_file) {
 	buffer_destroy_from_heap(output);
 
 	/* Our matrix: */
-	root = mcJSON_CreateArray();
+	root = mcJSON_CreateArray(NULL);
 	for (i = 0; i < 3; i++) {
-		mcJSON_AddItemToArray(root, mcJSON_CreateIntArray(numbers[i], 3));
+		mcJSON_AddItemToArray(root, mcJSON_CreateIntArray(numbers[i], 3, NULL));
 	}
 
 	/*mcJSON_ReplaceItemInArray(root,1,mcJSON_CreateString("Replacement")); */
@@ -140,16 +140,16 @@ int create_objects(FILE *output_file) {
 
 
 	/* Our "gallery" item: */
-	root = mcJSON_CreateObject();
-	mcJSON_AddItemToObject(root, "Image", img = mcJSON_CreateObject());
-	mcJSON_AddNumberToObject(img, "Width", 800);
-	mcJSON_AddNumberToObject(img, "Height", 600);
-	mcJSON_AddStringToObject(img, "Title", "View from 15th Floor");
-	mcJSON_AddItemToObject(img, "Thumbnail", thm = mcJSON_CreateObject());
-	mcJSON_AddStringToObject(thm, "Url", "http:/*www.example.com/image/481989943");
-	mcJSON_AddNumberToObject(thm, "Height", 125);
-	mcJSON_AddStringToObject(thm, "Width", "100");
-	mcJSON_AddItemToObject(img, "IDs", mcJSON_CreateIntArray(ids, 4));
+	root = mcJSON_CreateObject(NULL);
+	mcJSON_AddItemToObject(root, "Image", img = mcJSON_CreateObject(NULL));
+	mcJSON_AddNumberToObject(img, "Width", 800, NULL);
+	mcJSON_AddNumberToObject(img, "Height", 600, NULL);
+	mcJSON_AddStringToObject(img, "Title", "View from 15th Floor", NULL);
+	mcJSON_AddItemToObject(img, "Thumbnail", thm = mcJSON_CreateObject(NULL));
+	mcJSON_AddStringToObject(thm, "Url", "http:/*www.example.com/image/481989943", NULL);
+	mcJSON_AddNumberToObject(thm, "Height", 125, NULL);
+	mcJSON_AddStringToObject(thm, "Width", "100", NULL);
+	mcJSON_AddItemToObject(img, "IDs", mcJSON_CreateIntArray(ids, 4, NULL));
 
 	output = mcJSON_Print(root);
 	mcJSON_Delete(root);
@@ -164,20 +164,20 @@ int create_objects(FILE *output_file) {
 
 	/* Our array of "records": */
 
-	root = mcJSON_CreateArray();
+	root = mcJSON_CreateArray(NULL);
 	for (i = 0; i < 2; i++) {
-		mcJSON_AddItemToArray(root, fld = mcJSON_CreateObject());
-		mcJSON_AddStringToObject(fld, "precision", fields[i].precision);
-		mcJSON_AddNumberToObject(fld, "Latitude", fields[i].lat);
-		mcJSON_AddNumberToObject(fld, "Longitude", fields[i].lon);
-		mcJSON_AddStringToObject(fld, "Address", fields[i].address);
-		mcJSON_AddStringToObject(fld, "City", fields[i].city);
-		mcJSON_AddStringToObject(fld, "State", fields[i].state);
-		mcJSON_AddStringToObject(fld, "Zip", fields[i].zip);
-		mcJSON_AddStringToObject(fld, "Country", fields[i].country);
+		mcJSON_AddItemToArray(root, fld = mcJSON_CreateObject(NULL));
+		mcJSON_AddStringToObject(fld, "precision", fields[i].precision, NULL);
+		mcJSON_AddNumberToObject(fld, "Latitude", fields[i].lat, NULL);
+		mcJSON_AddNumberToObject(fld, "Longitude", fields[i].lon, NULL);
+		mcJSON_AddStringToObject(fld, "Address", fields[i].address, NULL);
+		mcJSON_AddStringToObject(fld, "City", fields[i].city, NULL);
+		mcJSON_AddStringToObject(fld, "State", fields[i].state, NULL);
+		mcJSON_AddStringToObject(fld, "Zip", fields[i].zip, NULL);
+		mcJSON_AddStringToObject(fld, "Country", fields[i].country, NULL);
 	}
 
-	/*	mcJSON_ReplaceItemInObject(mcJSON_GetArrayItem(root,1),"City",mcJSON_CreateIntArray(ids,4)); */
+	/*	mcJSON_ReplaceItemInObject(mcJSON_GetArrayItem(root,1),"City",mcJSON_CreateIntArray(ids,4,NULL)); */
 
 	output = mcJSON_Print(root);
 	mcJSON_Delete(root);
@@ -190,8 +190,8 @@ int create_objects(FILE *output_file) {
 	}
 	buffer_destroy_from_heap(output);
 
-	root = mcJSON_CreateObject();
-	mcJSON_AddNumberToObject(root, "number", 1.0/0.0);
+	root = mcJSON_CreateObject(NULL);
+	mcJSON_AddNumberToObject(root, "number", 1.0/0.0, NULL);
 
 	output = mcJSON_Print(root);
 	mcJSON_Delete(root);
@@ -205,9 +205,9 @@ int create_objects(FILE *output_file) {
 	buffer_destroy_from_heap(output);
 
 	/* Check mcJSON_GetObjectItem and make sure it's case sensitive */
-	root = mcJSON_CreateObject();
-	mcJSON_AddNumberToObject(root, "a", 1);
-	mcJSON_AddNumberToObject(root, "A", 2);
+	root = mcJSON_CreateObject(NULL);
+	mcJSON_AddNumberToObject(root, "a", 1, NULL);
+	mcJSON_AddNumberToObject(root, "A", 2, NULL);
 
 	output = mcJSON_Print(root);
 	if (output == NULL) {

--- a/test/test-objects.c
+++ b/test/test-objects.c
@@ -84,8 +84,8 @@ int create_objects(FILE *output_file) {
 
 	/* Our "Video" datatype: */
 	root = mcJSON_CreateObject(NULL);
-	mcJSON_AddItemToObject(root, "name", mcJSON_CreateString("Jack (\"Bee\") Nimble", NULL));
-	mcJSON_AddItemToObject(root, "format", fmt=mcJSON_CreateObject(NULL));
+	mcJSON_AddItemToObject(root, "name", mcJSON_CreateString("Jack (\"Bee\") Nimble", NULL), NULL);
+	mcJSON_AddItemToObject(root, "format", fmt=mcJSON_CreateObject(NULL), NULL);
 	mcJSON_AddStringToObject(fmt, "type", "rect", NULL);
 	mcJSON_AddNumberToObject(fmt, "width", 1920, NULL);
 	mcJSON_AddNumberToObject(fmt, "height", 1080, NULL);
@@ -122,7 +122,7 @@ int create_objects(FILE *output_file) {
 	/* Our matrix: */
 	root = mcJSON_CreateArray(NULL);
 	for (i = 0; i < 3; i++) {
-		mcJSON_AddItemToArray(root, mcJSON_CreateIntArray(numbers[i], 3, NULL));
+		mcJSON_AddItemToArray(root, mcJSON_CreateIntArray(numbers[i], 3, NULL), NULL);
 	}
 
 	/*mcJSON_ReplaceItemInArray(root,1,mcJSON_CreateString("Replacement")); */
@@ -141,15 +141,15 @@ int create_objects(FILE *output_file) {
 
 	/* Our "gallery" item: */
 	root = mcJSON_CreateObject(NULL);
-	mcJSON_AddItemToObject(root, "Image", img = mcJSON_CreateObject(NULL));
+	mcJSON_AddItemToObject(root, "Image", img = mcJSON_CreateObject(NULL), NULL);
 	mcJSON_AddNumberToObject(img, "Width", 800, NULL);
 	mcJSON_AddNumberToObject(img, "Height", 600, NULL);
 	mcJSON_AddStringToObject(img, "Title", "View from 15th Floor", NULL);
-	mcJSON_AddItemToObject(img, "Thumbnail", thm = mcJSON_CreateObject(NULL));
+	mcJSON_AddItemToObject(img, "Thumbnail", thm = mcJSON_CreateObject(NULL), NULL);
 	mcJSON_AddStringToObject(thm, "Url", "http:/*www.example.com/image/481989943", NULL);
 	mcJSON_AddNumberToObject(thm, "Height", 125, NULL);
 	mcJSON_AddStringToObject(thm, "Width", "100", NULL);
-	mcJSON_AddItemToObject(img, "IDs", mcJSON_CreateIntArray(ids, 4, NULL));
+	mcJSON_AddItemToObject(img, "IDs", mcJSON_CreateIntArray(ids, 4, NULL), NULL);
 
 	output = mcJSON_Print(root);
 	mcJSON_Delete(root);
@@ -166,7 +166,7 @@ int create_objects(FILE *output_file) {
 
 	root = mcJSON_CreateArray(NULL);
 	for (i = 0; i < 2; i++) {
-		mcJSON_AddItemToArray(root, fld = mcJSON_CreateObject(NULL));
+		mcJSON_AddItemToArray(root, fld = mcJSON_CreateObject(NULL), NULL);
 		mcJSON_AddStringToObject(fld, "precision", fields[i].precision, NULL);
 		mcJSON_AddNumberToObject(fld, "Latitude", fields[i].lat, NULL);
 		mcJSON_AddNumberToObject(fld, "Longitude", fields[i].lon, NULL);

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -203,8 +203,8 @@ int main(int argc, char **argv) {
 	if (output_file != NULL) {
 		fprintf(output_file, "JSON Pointer construct\n");
 	}
-	object = mcJSON_CreateObject();
-	nums = mcJSON_CreateIntArray(numbers, 10);
+	object = mcJSON_CreateObject(NULL);
+	nums = mcJSON_CreateIntArray(numbers, 10, NULL);
 	num6 = mcJSON_GetArrayItem(nums, 6);
 	mcJSON_AddItemToObject(object, "numbers", nums);
 	char *temp = mcJSONUtils_FindPointerFromObjectTo(object, num6);
@@ -263,10 +263,10 @@ int main(int argc, char **argv) {
 	/*TODO do some cleanup */
 
 	/* JSON Sort test: */
-	sortme = mcJSON_CreateObject();
+	sortme = mcJSON_CreateObject(NULL);
 	for (i = 0; i < 26; i++) {
 		buf[0] = random[i];
-		mcJSON_AddItemToObject(sortme, buf, mcJSON_CreateNumber(1));
+		mcJSON_AddItemToObject(sortme, buf, mcJSON_CreateNumber(1, NULL));
 	}
 	buffer_t *before = mcJSON_PrintUnformatted(sortme);
 	mcJSONUtils_SortObject(sortme);

--- a/test/test_utils.c
+++ b/test/test_utils.c
@@ -206,7 +206,7 @@ int main(int argc, char **argv) {
 	object = mcJSON_CreateObject(NULL);
 	nums = mcJSON_CreateIntArray(numbers, 10, NULL);
 	num6 = mcJSON_GetArrayItem(nums, 6);
-	mcJSON_AddItemToObject(object, "numbers", nums);
+	mcJSON_AddItemToObject(object, "numbers", nums, NULL);
 	char *temp = mcJSONUtils_FindPointerFromObjectTo(object, num6);
 	if (temp == NULL) {
 		fprintf(stderr, "ERROR: JSON Pointer construct 1 failed!\n");
@@ -266,7 +266,7 @@ int main(int argc, char **argv) {
 	sortme = mcJSON_CreateObject(NULL);
 	for (i = 0; i < 26; i++) {
 		buf[0] = random[i];
-		mcJSON_AddItemToObject(sortme, buf, mcJSON_CreateNumber(1, NULL));
+		mcJSON_AddItemToObject(sortme, buf, mcJSON_CreateNumber(1, NULL), NULL);
 	}
 	buffer_t *before = mcJSON_PrintUnformatted(sortme);
 	mcJSONUtils_SortObject(sortme);


### PR DESCRIPTION
This feature allows to parse the entire JSON-Tree into one contiguous memory region. This can massively improve performance in situations where allocating memory is an expensive operation.

Note though, that if the buffer isn't big enough, parsing will fail.